### PR TITLE
changement du lien google maps du bowling

### DIFF
--- a/src/data/agenda.yml
+++ b/src/data/agenda.yml
@@ -3,7 +3,7 @@
     - Bowling, Limoges Sud / Feytiat
     - Chez Bernard, Limoges 
   locations-links:
-    - https://maps.app.goo.gl/dhfDNyUnYo598KoK8
+    - https://maps.app.goo.gl/qHMqV6We33w8h8hT8
     - https://maps.app.goo.gl/wYYpYP2zZPiBauBz5
   description: |
     Soirée Bowling de 19h30 à 22h ! Les professeurs, diplômés et étudiants en informatique y sont conviés !


### PR DESCRIPTION
le lien google maps du bowling était le seul qui emmenait vers une vue satellite au lieu d'une carte, donc je l'ai changé  